### PR TITLE
fix: Retain the 'features' value from the step1 in timings.json at the step2

### DIFF
--- a/run_aws_alphafold.py
+++ b/run_aws_alphafold.py
@@ -328,6 +328,16 @@ def predict_structure(
     logging.info('Final timings for %s: %s', fasta_name, timings)
 
     timings_output_path = os.path.join(output_dir, 'timings.json')
+
+    ### ---------------------------------------------    
+    ### Modified to add support for 2-step jobs
+    ### Add back the features timing from the step 1 if timings.json presents
+    if os.path.exists(timings_output_path):
+        with open(timings_output_path, 'r') as f:
+            features_timing = json.load(f)
+        timings['features'] = features_timing['features']
+    ### --------------------------------------------- 
+
     with open(timings_output_path, 'w') as f:
         f.write(json.dumps(timings, indent=4))
 


### PR DESCRIPTION
*Issue #*
Currently the step 2 is overwriting the 'features' timing value in step 1.

*Description of changes:*
Read the 'features' timing value from timings.json generated from step 1, and include it the updated timing.json at step 2.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
